### PR TITLE
Tweak guide now that it's posted to the website

### DIFF
--- a/docs/LICENSE-CC-BY-4.0.md
+++ b/docs/LICENSE-CC-BY-4.0.md
@@ -1,0 +1,157 @@
+# Creative Commons Attribution 4.0 International
+
+Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
+
+**Using Creative Commons Public Licenses**
+
+Creative Commons public licenses provide a standard set of terms and conditions that creators and other rights holders may use to share original works of authorship and other material subject to copyright and certain other rights specified in the public license below. The following considerations are for informational purposes only, are not exhaustive, and do not form part of our licenses.
+
+* __Considerations for licensors:__ Our public licenses are intended for use by those authorized to give the public permission to use material in ways otherwise restricted by copyright and certain other rights. Our licenses are irrevocable. Licensors should read and understand the terms and conditions of the license they choose before applying it. Licensors should also secure all rights necessary before applying our licenses so that the public can reuse the material as expected. Licensors should clearly mark any material not subject to the license. This includes other CC-licensed material, or material used under an exception or limitation to copyright. [More considerations for licensors](http://wiki.creativecommons.org/Considerations_for_licensors_and_licensees#Considerations_for_licensors).
+
+* __Considerations for the public:__ By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensor’s permission is not necessary for any reason–for example, because of any applicable exception or limitation to copyright–then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. [More considerations for the public](http://wiki.creativecommons.org/Considerations_for_licensors_and_licensees#Considerations_for_licensees).
+
+## Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
+
+### Section 1 – Definitions.
+
+a. __Adapted Material__ means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
+
+b. __Adapter's License__ means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
+
+c. __Copyright and Similar Rights__ means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+d. __Effective Technological Measures__ means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+
+e. __Exceptions and Limitations__ means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+
+f. __Licensed Material__ means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+
+g. __Licensed Rights__ means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+
+h. __Licensor__ means the individual(s) or entity(ies) granting rights under this Public License.
+
+i. __Share__ means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+
+j. __Sui Generis Database Rights__ means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+
+k. __You__ means the individual or entity exercising the Licensed Rights under this Public License. __Your__ has a corresponding meaning.
+
+### Section 2 – Scope.
+
+a. ___License grant.___
+
+   1. Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+
+       A. reproduce and Share the Licensed Material, in whole or in part; and
+
+       B. produce, reproduce, and Share Adapted Material.
+
+   2. __Exceptions and Limitations.__ For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+
+   3. __Term.__ The term of this Public License is specified in Section 6(a).
+
+   4. __Media and formats; technical modifications allowed.__ The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
+
+   5. __Downstream recipients.__
+
+       A. __Offer from the Licensor – Licensed Material.__ Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+
+       B. __No downstream restrictions.__ You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+
+   6. __No endorsement.__ Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
+
+b. ___Other rights.___
+
+   1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+
+   2. Patent and trademark rights are not licensed under this Public License.
+
+   3. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.
+
+### Section 3 – License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+
+a. ___Attribution.___
+
+   1. If You Share the Licensed Material (including in modified form), You must:
+
+       A. retain the following if it is supplied by the Licensor with the Licensed Material:
+
+         i. identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+
+         ii. a copyright notice;
+
+         iii. a notice that refers to this Public License;
+
+         iv. a notice that refers to the disclaimer of warranties;
+
+         v. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+
+       B. indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
+
+       C. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+
+   2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+
+   3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+
+   4. If You Share Adapted Material You produce, the Adapter's License You apply must not prevent recipients of the Adapted Material from complying with this Public License.
+
+### Section 4 – Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+
+a. for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database;
+
+b. if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material; and
+
+c. You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+
+### Section 5 – Disclaimer of Warranties and Limitation of Liability.
+
+a. __Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.__
+
+b. __To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.__
+
+c. The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+
+### Section 6 – Term and Termination.
+
+a. This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+
+b. Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
+
+   1. automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+
+   2. upon express reinstatement by the Licensor.
+
+   For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+
+c. For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+
+d. Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+
+### Section 7 – Other Terms and Conditions.
+
+a. The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+
+b. Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+
+### Section 8 – Interpretation.
+
+a. For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+
+b. To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+
+c. No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+
+d. Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+
+> Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the “Licensor.” Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at [creativecommons.org/policies](http://creativecommons.org/policies), Creative Commons does not authorize the use of the trademark “Creative Commons” or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.
+>
+> Creative Commons may be contacted at creativecommons.org

--- a/docs/LICENSE.txt
+++ b/docs/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-present David A. Wheeler and Metamath-lamp guide contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,16 +11,22 @@ More information on metamath-lamp is available at the
 [metamath-lamp source code repository](https://github.com/expln/metamath-lamp).
 
 This is a guide for metamath-lamp, including both a
-user guide (tutorial) and a reference guide.
-We'll begin with a "quick start"
-(a brief introduction on how to start and use metamath-lamp).
-This will be followed by a user guide / tutorial,
-which is primarily a sequence of worked examples showing how to use
-the metamath-lamp tool
-(starting with a proof that two plus two equals four).
-The rest of this guide is a reference guide,
-explaining the various parts of the user interface.
-We conclude with how to get or share more information.
+user guide (tutorial) and a reference guide. This includes:
+
+* [Quick start](#quickstart) -
+  a brief introduction on how to start and use metamath-lamp.
+* [Sample Screenshot](#sample-screenshot)
+* [User guide (tutorial)](#user-guide-tutorial) -
+  this user guide is primarily
+  which is primarily a sequence of worked examples showing how to use
+  the metamath-lamp tool, including proofs that
+  [2 + 2 = 4 (2p2e4)](proof-2--2--4) and that
+  [the reciprocal of the cotangent is tangent (reccot)](#proof-the-reciprocal-of-the-cotangent-is-tangent-reccot).
+* [Reference guide](#reference-guide) - this walks through the
+  user interface, explaining its various parts.
+* [Help, feedback, and contributions](#help-feedback-and-contributions)
+* [Licensing](#licensing)
+* [Authors and Reviewers](#authors-and-reviewers)
 
 Metamath-lamp is a new proof assistant for creating Metamath proofs.
 As a result, it currently lacks some functionality, such as
@@ -35,6 +41,9 @@ Note that metamath-lamp changes over time, so some of this guide
 may not exactly match what you see. If you see a difference, please
 let us know so we can fix this guide. We try to make this guide
 match the tool it's describing.
+
+You can get the latest version of this *Metamath-lamp guide* at
+&lt;[https://lamp-guide.metamath.org/](https://lamp-guide.metamath.org/)&gt;.
 
 ## Quickstart
 
@@ -75,6 +84,21 @@ On a touchscreen (like a smartphone), a quick touch and release on a UI
 control is the same as a left click.
 Metamath-lamp has some actions that are quickly accessed using Alt+left click
 (hold down the Alt aka Opt key, and while holding it use left click).
+
+## Sample Screenshot
+
+Here's a sample screenshot to give you an idea of what
+using metamath-lamp looks like (proving that 2 + 2 = 4):
+
+![Screenshot of 2 + 2 = 4](./metamath-lamp-example.png)
+
+You can start using metamath-lamp immediately by visiting the
+[main Metamath-lamp web site](https://expln.github.io/lamp/latest/index.html).
+You can even start using metamath-lamp preloaded with a proof state,
+for example, that
+[2 + 2 = 4](https://expln.github.io/lamp/latest/index.html?editorState=eyJzcmNzIjpbeyJ0eXAiOiJXZWIiLCJmaWxlTmFtZSI6IiIsInVybCI6Imh0dHBzOi8vdXMubWV0YW1hdGgub3JnL21ldGFtYXRoL3NldC5tbSIsInJlYWRJbnN0ciI6IlN0b3BCZWZvcmUiLCJsYWJlbCI6IjJwMmU0In1dLCJkZXNjciI6IlByb3ZlIHRoYXQgMiArIDIgPSA0LiIsInZhcnNUZXh0IjoiIiwiZGlzalRleHQiOiIiLCJzdG10cyI6W3sibGFiZWwiOiI5IiwidHlwIjoicCIsImNvbnQiOiJ8LSAxIGUuIENDIiwianN0ZlRleHQiOiI6IGF4LTFjbiJ9LHsibGFiZWwiOiI4IiwidHlwIjoicCIsImNvbnQiOiJ8LSAyIGUuIENDIiwianN0ZlRleHQiOiI6IDJjbiJ9LHsibGFiZWwiOiI1IiwidHlwIjoicCIsImNvbnQiOiJ8LSAyID0gKCAxICsgMSApIiwianN0ZlRleHQiOiI6IGRmLTIifSx7ImxhYmVsIjoiNiIsInR5cCI6InAiLCJjb250IjoifC0gKCAyICsgMiApID0gKCAyICsgKCAxICsgMSApICkiLCJqc3RmVGV4dCI6IjUgOiBvdmVxMmkifSx7ImxhYmVsIjoiMiIsInR5cCI6InAiLCJjb250IjoifC0gMyA9ICggMiArIDEgKSIsImpzdGZUZXh0IjoiOiBkZi0zIn0seyJsYWJlbCI6IjEiLCJ0eXAiOiJwIiwiY29udCI6InwtIDQgPSAoIDMgKyAxICkiLCJqc3RmVGV4dCI6IjogZGYtNCJ9LHsibGFiZWwiOiIzIiwidHlwIjoicCIsImNvbnQiOiJ8LSAoIDMgKyAxICkgPSAoICggMiArIDEgKSArIDEgKSIsImpzdGZUZXh0IjoiMiA6IG92ZXExaSJ9LHsibGFiZWwiOiI0IiwidHlwIjoicCIsImNvbnQiOiJ8LSA0ID0gKCAoIDIgKyAxICkgKyAxICkiLCJqc3RmVGV4dCI6IjEgMyA6IGVxdHJpIn0seyJsYWJlbCI6IjciLCJ0eXAiOiJwIiwiY29udCI6InwtICggKCAyICsgMSApICsgMSApID0gKCAyICsgKCAxICsgMSApICkiLCJqc3RmVGV4dCI6IjggOSA5IDogYWRkYXNzaSJ9LHsibGFiZWwiOiIycDJlNCIsInR5cCI6InAiLCJjb250IjoifC0gKCAyICsgMiApID0gNCIsImpzdGZUZXh0IjoiNyA0IDYgOiAzZXF0cjRyaSJ9XX0=)
+or
+[the tangent is equal to the reciprocal of the cotangent]( https://expln.github.io/lamp/latest/index.html?editorState=eyJzcmNzIjpbeyJ0eXAiOiJXZWIiLCJmaWxlTmFtZSI6IiIsInVybCI6Imh0dHBzOi8vdXMubWV0YW1hdGgub3JnL21ldGFtYXRoL3NldC5tbSIsInJlYWRJbnN0ciI6IlN0b3BCZWZvcmUiLCJsYWJlbCI6InJlY2NvdCJ9XSwiZGVzY3IiOiJQcm92ZSB0aGF0IHRoZSB0YW5nZW50IGlzIGVxdWFsIHRvIHRoZSByZWNpcHJvY2FsIG9mIHRoZSBjb3RhbmdlbnQuIiwidmFyc1RleHQiOiIiLCJkaXNqVGV4dCI6IiIsInN0bXRzIjpbeyJsYWJlbCI6IjgiLCJ0eXAiOiJwIiwiY29udCI6InwtICggQSBlLiBDQyAtPiAoIHNpbiBgIEEgKSBlLiBDQyApIiwianN0ZlRleHQiOiI6IHNpbmNsIn0seyJsYWJlbCI6IjciLCJ0eXAiOiJwIiwiY29udCI6InwtICggQSBlLiBDQyAtPiAoIGNvcyBgIEEgKSBlLiBDQyApIiwianN0ZlRleHQiOiI6IGNvc2NsIn0seyJsYWJlbCI6IjEiLCJ0eXAiOiJwIiwiY29udCI6InwtICggKCAoICggY29zIGAgQSApIGUuIENDIC9cXCAoIGNvcyBgIEEgKSA9Lz0gMCApIC9cXCAoICggc2luIGAgQSApIGUuIENDIC9cXCAoIHNpbiBgIEEgKSA9Lz0gMCApICkgLT4gKCAxIC8gKCAoIGNvcyBgIEEgKSAvICggc2luIGAgQSApICkgKSA9ICggKCBzaW4gYCBBICkgLyAoIGNvcyBgIEEgKSApICkiLCJqc3RmVGV4dCI6IjogcmVjZGl2In0seyJsYWJlbCI6IjkiLCJ0eXAiOiJwIiwiY29udCI6InwtICggKCAoIEEgZS4gQ0MgL1xcICggY29zIGAgQSApID0vPSAwICkgL1xcICggKCBzaW4gYCBBICkgZS4gQ0MgL1xcICggc2luIGAgQSApID0vPSAwICkgKSAtPiAoIDEgLyAoICggY29zIGAgQSApIC8gKCBzaW4gYCBBICkgKSApID0gKCAoIHNpbiBgIEEgKSAvICggY29zIGAgQSApICkgKSIsImpzdGZUZXh0IjoiNyAxIDogc3lsYW5sMSJ9LHsibGFiZWwiOiIxMCIsInR5cCI6InAiLCJjb250IjoifC0gKCAoICggQSBlLiBDQyAvXFwgKCBjb3MgYCBBICkgPS89IDAgKSAvXFwgKCBBIGUuIENDIC9cXCAoIHNpbiBgIEEgKSA9Lz0gMCApICkgLT4gKCAxIC8gKCAoIGNvcyBgIEEgKSAvICggc2luIGAgQSApICkgKSA9ICggKCBzaW4gYCBBICkgLyAoIGNvcyBgIEEgKSApICkiLCJqc3RmVGV4dCI6IjggOSA6IHN5bGFucjEifSx7ImxhYmVsIjoiMTEiLCJ0eXAiOiJwIiwiY29udCI6InwtICggKCBBIGUuIENDIC9cXCAoIHNpbiBgIEEgKSA9Lz0gMCAvXFwgKCBjb3MgYCBBICkgPS89IDAgKSAtPiAoIDEgLyAoICggY29zIGAgQSApIC8gKCBzaW4gYCBBICkgKSApID0gKCAoIHNpbiBgIEEgKSAvICggY29zIGAgQSApICkgKSIsImpzdGZUZXh0IjoiMTAgOiB1dW4yMTMxcDEifSx7ImxhYmVsIjoiMyIsInR5cCI6InAiLCJjb250IjoifC0gKCAoIEEgZS4gQ0MgL1xcICggc2luIGAgQSApID0vPSAwICkgLT4gKCBjb3QgYCBBICkgPSAoICggY29zIGAgQSApIC8gKCBzaW4gYCBBICkgKSApIiwianN0ZlRleHQiOiI6IGNvdHZhbCJ9LHsibGFiZWwiOiI1IiwidHlwIjoicCIsImNvbnQiOiJ8LSAoICggQSBlLiBDQyAvXFwgKCBzaW4gYCBBICkgPS89IDAgL1xcICggY29zIGAgQSApID0vPSAwICkgLT4gKCBjb3QgYCBBICkgPSAoICggY29zIGAgQSApIC8gKCBzaW4gYCBBICkgKSApIiwianN0ZlRleHQiOiIzIDogM2FkYW50MyJ9LHsibGFiZWwiOiI2IiwidHlwIjoicCIsImNvbnQiOiJ8LSAoICggQSBlLiBDQyAvXFwgKCBzaW4gYCBBICkgPS89IDAgL1xcICggY29zIGAgQSApID0vPSAwICkgLT4gKCAxIC8gKCBjb3QgYCBBICkgKSA9ICggMSAvICggKCBjb3MgYCBBICkgLyAoIHNpbiBgIEEgKSApICkgKSIsImpzdGZUZXh0IjoiNSA6IG92ZXEyZCJ9LHsibGFiZWwiOiIyIiwidHlwIjoicCIsImNvbnQiOiJ8LSAoICggQSBlLiBDQyAvXFwgKCBjb3MgYCBBICkgPS89IDAgKSAtPiAoIHRhbiBgIEEgKSA9ICggKCBzaW4gYCBBICkgLyAoIGNvcyBgIEEgKSApICkiLCJqc3RmVGV4dCI6IjogdGFudmFsIn0seyJsYWJlbCI6IjQiLCJ0eXAiOiJwIiwiY29udCI6InwtICggKCBBIGUuIENDIC9cXCAoIHNpbiBgIEEgKSA9Lz0gMCAvXFwgKCBjb3MgYCBBICkgPS89IDAgKSAtPiAoIHRhbiBgIEEgKSA9ICggKCBzaW4gYCBBICkgLyAoIGNvcyBgIEEgKSApICkiLCJqc3RmVGV4dCI6IjIgOiAzYWRhbnQyIn0seyJsYWJlbCI6InJlY2NvdCIsInR5cCI6InAiLCJjb250IjoifC0gKCAoIEEgZS4gQ0MgL1xcICggc2luIGAgQSApID0vPSAwIC9cXCAoIGNvcyBgIEEgKSA9Lz0gMCApIC0-ICggdGFuIGAgQSApID0gKCAxIC8gKCBjb3QgYCBBICkgKSApIiwianN0ZlRleHQiOiIxMSA2IDQgOiAzZXF0cjRyZCJ9XX0=).
 
 ## User guide (tutorial)
 
@@ -1066,10 +1090,15 @@ Try to create your own proof, consulting the known proof when you get stuck.
 
 You can use "import to JSON" to load worked examples of metamath-lamp.
 
-For example, we have completed examples of:
+For example, we have completed examples of these proofs available in
+JSON format:
 
-* [2p2e4](https://raw.githubusercontent.com/expln/metamath-lamp/master/docs/2p2e4.lamp.json)
-* [reccot](https://raw.githubusercontent.com/expln/metamath-lamp/master/docs/reccot.lamp.json).
+* [2p2e4](./2p2e4.lamp.json)
+* [reccot](./reccot.lamp.json)
+
+You can also generate a URL that includes the proof state, and share that
+URL with anyone.
+When anyone views that URL, they will load that same state.
 
 ### Notes about Metamath databases
 
@@ -1140,7 +1169,9 @@ The rest of this guide is a reference guide,
 where we will walk through various portions of the metamath-lamp
 user interface to help you understand how to use it.
 
-## Loading source Metamath databases to create the proof context
+## Reference guide
+
+### Loading source Metamath databases to create the proof context
 
 Before creating a mathematical proof using metamath-lamp, you must
 first load at least one Metamath database and decide how much of those
@@ -1191,7 +1222,7 @@ Once you've selected all sources, select "Apply changes" to process these
 source databases. After it's applied, the source selection section
 is hidden and you can start creating a proof with the proof editor.
 
-## Main tabs: Settings and Editor
+### Main tabs: Settings and Editor
 
 Once you've loaded the context,
 at the top there is a tab bar with two tabs, "Settings" and "Editor".
@@ -1200,13 +1231,13 @@ The "Editor" tab is the main view that lets you see and edit a proof.
 The "Settings" tab lets you change the editor configuration to your liking,
 We'll cover the Settings tab later; let's focus on the Editor tab.
 
-## Editor tab
+### Editor tab
 
 The Editor tab lets you edit a proof; it starts empty.
 You will create a list of statements in the editor that will eventually
 result in a proof.
 
-### Fundamental proof information
+#### Fundamental proof information
 
 At the top is fundamental proof information,
 specifically fields for its description, variables, and disjoints.
@@ -1214,7 +1245,7 @@ You don't *need* to fill in a description or variable list to begin a proof.
 In many cases you won't need to specify disjoints for a proof, but sometimes
 you do. Here is information on these fields.
 
-#### Description
+##### Description
 
 This field can't be edited with a simple left-click;
 you must use alt+left click.
@@ -1223,7 +1254,7 @@ you must use alt+left click.
 the generated final (compressed) proof. That is an idea that is
 being considered.
 
-#### Variables
+##### Variables
 
 This section shows a list of work variables and local variables,
 one variable per line.
@@ -1260,7 +1291,7 @@ is exported as part of the proof.
 If you don't want to export the local variable, you can replace the
 local variables with global variables before generating a proof.
 
-#### Disjoints
+##### Disjoints
 
 The disjoints field
 presents a list of disjoint variables, one disjoint expression per line.
@@ -1285,7 +1316,7 @@ variable `x` must not occur in the wff `ph`.
 
 For more information, see the Metamath book.
 
-### How to state the goal and hypotheses
+#### How to state the goal and hypotheses
 
 To prove something, you must first tell the system what to prove and
 any special hypotheses to use. To do that:
@@ -1305,7 +1336,7 @@ any special hypotheses to use. To do that:
 You're now ready to create a proof. Let's first look at the editor command's
 tab bar.
 
-### Editor command tab bar
+#### Editor command tab bar
 
 The Editor tab has another tab bar with a variety of icons for commands.
 You can hover over an icon to see what the command does. Here are their
@@ -1328,7 +1359,7 @@ icons and meanings:
 Under the editor command tab bar is basic information about the proof
 (such as its description).
 
-### Basic information about the proof
+#### Basic information about the proof
 
 The basic information about the proof are the proof's description,
 variables, and disjoints. Click on the *section name* to edit this
@@ -1361,7 +1392,7 @@ Omitted, since description is currently not generated as a comment:
 Under the basic information about the proof
 are a list of statements in the proof.
 
-### List of statements in the proof
+#### List of statements in the proof
 
 The list of statements (aka steps) of the proof follows the basic information
 about the proof.
@@ -1438,7 +1469,7 @@ Each statement is presented in the following left-to-right order:
   by using Alt+left click ("alt" is sometimes labelled "opt").
   For more about selecting parts of a statement, see the next section.
 
-### Selecting parts of a statement
+#### Selecting parts of a statement
 
 What we've shown so far is enough to create any proof.
 However, it's very common when creating a proof to want to copy
@@ -1469,7 +1500,7 @@ You can use the selector dialogue as follows:
 * Edit: Start editing with the current text selected.
 * Close: Close this statement part selection dialogue box.
 
-### Search patterns
+#### Search patterns
 
 The "magnifying glass" icon enables you to search for a statement
 that matches a given pattern.
@@ -1499,7 +1530,7 @@ Therefore, a search for `0 ->` will match the conclusion
 because the conclusion has a `0` constant which is later followed by a
 `->` constant.
 
-### Replacement
+#### Replacement
 
 Select the icon "A with arrow icon under it"
 (apply a substitution) to substitute
@@ -1522,7 +1553,7 @@ When you press "Find Substitution" the tool will determine if it
 can apply this substitution (that is, if the results are valid types
 everywhere). If it is, you may select "Apply" to apply it.
 
-### Proving bottom-up
+#### Proving bottom-up
 
 If you select one statement and then select unify, you'll enter a
 "proving bottom-up" dialogue.
@@ -1552,7 +1583,7 @@ and the time it takes to do it,
 Therefore, selecting the *right* options for your circumstance
 in the proving bottom-up dialogue box can be very important.
 
-### Proving bottom-up dialogue box options
+#### Proving bottom-up dialogue box options
 
 This dialogue has the following options:
 
@@ -1665,7 +1696,7 @@ certain functions of the mmj2 tool:
   must be used as the justification. You can do the same by
   selecting it as the "Label".
 
-## Settings
+### Settings
 
 The "Settings" tab lets you configure metamath-lamp to your liking.
 
@@ -1695,19 +1726,28 @@ is the
 You can find a lot of general information about Metamath at the
 [Metamath home page](https://us.metamath.org/index.html).
 
-We'd love feedback and contributions on the metamath-lamp tool.
-For tool feedback on changes you'd like to see, please file an issue at the
+If you have feedback (issues) or contributions (pull requests)
+for this guide, please do that via the
+[Metamath-lamp guide repository](https://github.com/metamath/lamp-guide/).
+
+For feedback or proposed changes to the Metamath-lamp
+tool itself, please file issues or create pull requests against the
 [metamath-lamp source code repository](https://github.com/expln/metamath-lamp).
-If you'd like to make contributions to its code and/or documentations,
-please propose them as pull requests to the same
-[metamath-lamp source code repository](https://github.com/expln/metamath-lamp).
+
+If you're making a contribution to a Metamath database, such as a new
+proof, please contribute those as changes to the database's repository.
+For example, for `set.mm`, propose changes to the
+[set.mm repository](https://github.com/metamath/set.mm).
+If it's your first time, you should contact the mailing list; they
+would be *delighted* to help you complete that process.
+
 Thank you for your time.
 
-### Licensing
+## Licensing
 
 You may use, modify, and share this guide under the terms of *either*
 the [MIT license](./LICENSE.txt) or the
-[Creative Commons Attribution 4.0 International (CC-BY-4.0) license)[LICENSE-CC-BY-4.0.md].
+[Creative Commons Attribution 4.0 International (CC-BY-4.0) license](LICENSE-CC-BY-4.0.md).
 
 In short, this guide is licensed using the
 [SPDX license expression](https://github.com/david-a-wheeler/spdx-tutorial):
@@ -1716,7 +1756,11 @@ In short, this guide is licensed using the
 SPDX-License-Identifier: (MIT OR CC-BY-4.0)
 ~~~~
 
-### Authors and Reviewers
+Metamath-lamp is iicensed separately (in its case under the MIT license).
 
-This guide was written by David A. Wheeler (@david-a-wheeler)
-and reviewed by Igor Ieskov (@expln).
+## Authors and Reviewers
+
+This guide was written by
+[David A. Wheeler](https://dwheeler.com)
+([@david-a-wheeler](https://github.com/david-a-wheeler))
+and reviewed by Igor Ieskov ([@expln](https://github.com/expln).


### PR DESCRIPTION
Make a number of changes to the guide, including explaining how to download the latest version (the user may have printed it) and putting the screenshot into the guide itself.

I changed the heading levels of all the reference material so they're all under a "reference" section, that makes it easier to understand the overall document structure.

I made copies of the license files so there are 2 copies. That way, they're in the "expected" place (the root dir) and a directory that's going to the website (the source dir). Having 2 copies isn't ideal, but we don't expect them to change and this way we are certain to have a copy of the license handy. I doubt anyone will contest the license, but I always want to make licensing crystal-clear.