### PR TITLE
Add numbering to h5 (4th level headings)

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -30,13 +30,21 @@ h3:before {
     counter-increment: h3counter;
 }
 
+h4 {
+    counter-reset: h5counter;
+}
 h4:before {
     content: counter(h2counter) "." counter(h3counter) "." counter(h4counter) ".\0000a0\0000a0";
     counter-increment: h4counter;
 }
 
+h5:before {
+    content: counter(h2counter) "." counter(h3counter) "." counter(h4counter) "." counter(h5counter) ".\0000a0\0000a0";
+    counter-increment: h5counter;
+}
+
 /* Use class "nocount" to suppress the heading number */
-h2.nocount:before, h3.nocount:before, h4.nocount:before {
+h2.nocount:before, h3.nocount:before, h4.nocount:before, h5.nocount:before {
     content: none;
     counter-increment: none;
 }


### PR DESCRIPTION
We don't use many h5 (4th level) headings, but we do use them, so let's insert numbers for them as well. The numbers make it much easier to see "where you are" in the document.