### PR TITLE
Id the metamath-lamp version described (v10)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,7 @@ Note that metamath-lamp changes over time, so some of this guide
 may not exactly match what you see. If you see a difference, please
 let us know so we can fix this guide. We try to make this guide
 match the tool it's describing.
+This guide was written for release version v10.
 
 You can get the latest version of this *Metamath-lamp guide* at
 &lt;[https://lamp-guide.metamath.org/](https://lamp-guide.metamath.org/)&gt;.


### PR DESCRIPTION
Let's be clear which version of metamath-lamp is being described (in this case, v10).

When new releases occur, we can copy the "main" files into a subdirectory with the version name (e.g., "v10/"). That way we'll be able to include older versions of the documentation.