### PR TITLE
Add description to page metadata

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,3 +14,4 @@ defaults:
       path: "" # an empty string here means all files in the project
     values:
       description: This is a guide for metamath-lamp, including both a user guide (tutorial) and a reference guide. Metamath-lamp (Lite Assistant for Metamath Proofs) is a proof assistant for creating formal mathematical proofs in the Metamath system.
+      author: David A. Wheeler

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,3 +6,11 @@ title: null
 kramdown:
   # See: https://dieghernan.github.io/chulapa-101/cheatsheets/02-kramdown-cheat-sheet
   toc_levels: 2..6
+#
+# https://jekyllrb.com/docs/configuration/front-matter-defaults/
+defaults:
+  -
+    scope:
+      path: "" # an empty string here means all files in the project
+    values:
+      description: This is a guide for metamath-lamp, including both a user guide (tutorial) and a reference guide. Metamath-lamp (Lite Assistant for Metamath Proofs) is a proof assistant for creating formal mathematical proofs in the Metamath system.


### PR DESCRIPTION
I'll add the description to the `_config.yml` file so that I don't have to mess up the first lines of the markdown with a messy YAML header.