### PR TITLE
Say "version 10" not "v10"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ Note that metamath-lamp changes over time, so some of this guide
 may not exactly match what you see. If you see a difference, please
 let us know so we can fix this guide. We try to make this guide
 match the tool it's describing.
-This guide was written for release version `v10`.
+This guide was written for release version 10.
 
 The latest version of this
 [*Metamath-lamp guide*](https://lamp-guide.metamath.org/)


### PR DESCRIPTION
Say "version 10" not "v10".
It's clearer and simpler, for one thing.
Also, my spellchecker doesn't like "v10" and I don't want to keep adding v + NUMBER every time there's a new version.