### PR TITLE
Move "Export to URL" to later.

### DIFF
--- a/docs/11/index.md
+++ b/docs/11/index.md
@@ -805,49 +805,6 @@ have a `.lamp.json` suffix.
 > icon <img width="16" height="16" src="menu.svg" alt="menu"> (menu)
 > to dismiss the menu.
 
-#### Exporting to URL and temporary mode (TEMP mode)
-
-You can also export the current state into a URL:
-
-> Click on the
-> icon <img width="16" height="16" src="menu.svg" alt="menu"> (menu)
-> on the top right of the display.
-
-You can then share this URL, to easily share with others your current state.
-Anyone who opens this URL can see this state.
-
-**NOTE**: When you open a URL exported this way, Metamath-lamp
-is opened in *temporary mode (aka TEMP mode)*.
-Temporary mode is intended to let you view others' work
-*without* erasing your own.
-*Changes in temporary mode will not be stored* in
-the editor's content to the local storage.
-That means closing a browser or any internal error
-will erase the editor's content. That's why it is "temporary".
-
-To reduce the risk of accidentally doing something important
-while in temporary mode, the web page header starts with "TEMP"
-in any tab in temporary mode.
-Also, the first attempt to edit will remind you that you're in temporary mode
-and that changes will be discarded later. Here is the message
-you'll see the first time you try to edit in temporary mode:
-
-> Editing in TEMP mode
->
-> You are about to edit in TEMP mode. All changes you do in TEMP
-> mode will be erased upon closing current browser tab. If you want
-> to continue editing in NORMAL mode, please do the following actions:
-> \1) use "Export to JSON" to copy current editor state to the clipboard;
-> \2) open a new tab (or switch to an already opened tab) with
-> metamath-lamp in NORMAL mode; 3) use "Import from JSON" to load the
-> copied editor state from the clipboard.
-
-There's currently no mechanism to switch from temporary (TEMP) mode
-to regular mode.
-As noted in the warning, if you want to save results from TEMP mode, use
-"Export to JSON" to acquire the current state in JSON format.
-You can then use "Import from JSON" to load the results into a normal tab.
-
 #### Looking at proof steps
 
 In Metamath, *every* step of a valid completed proof must be an
@@ -2721,6 +2678,51 @@ steps that aren't instantly proved.
 If there are intermediate steps you need to prove to lead to the goal,
 just apply the same process - repeatedly work to prove those
 intermediate steps.
+
+#### Exporting to URL and temporary mode (TEMP mode)
+
+We can export this proof using "Export to JSON".
+However, let's briefly talk about an alternative, "Export to URL".
+
+> Click on the
+> icon <img width="16" height="16" src="menu.svg" alt="menu"> (menu)
+> on the top right of the display.
+> Click on "Export to URL"
+
+You can then share this URL, to easily share with others your current state.
+Anyone who opens this URL can see this state.
+
+**NOTE**: When you open a URL exported this way, Metamath-lamp
+is opened in *temporary mode (aka TEMP mode)*.
+Temporary mode is intended to let you view others' work
+*without* erasing your own.
+*Changes in temporary mode will not be stored* in
+the editor's content to the local storage.
+That means closing a browser or any internal error
+will erase the editor's content. That's why it is "temporary".
+
+To reduce the risk of accidentally doing something important
+while in temporary mode, the web page header starts with "TEMP"
+in any tab in temporary mode.
+Also, the first attempt to edit will remind you that you're in temporary mode
+and that changes will be discarded later. Here is the message
+you'll see the first time you try to edit in temporary mode:
+
+> Editing in TEMP mode
+>
+> You are about to edit in TEMP mode. All changes you do in TEMP
+> mode will be erased upon closing current browser tab. If you want
+> to continue editing in NORMAL mode, please do the following actions:
+> \1) use "Export to JSON" to copy current editor state to the clipboard;
+> \2) open a new tab (or switch to an already opened tab) with
+> metamath-lamp in NORMAL mode; 3) use "Import from JSON" to load the
+> copied editor state from the clipboard.
+
+There's currently no mechanism to switch from temporary (TEMP) mode
+to regular mode.
+As noted in the warning, if you want to save results from TEMP mode, use
+"Export to JSON" to acquire the current state in JSON format.
+You can then use "Import from JSON" to load the results into a normal tab.
 
 ### Creating your own examples from existing proofs
 


### PR DESCRIPTION
I expect TEMP mode is likely to have changes,
e.g., it may have a different visual display, and on loading a URL the tool may allow you to choose to use TEMP mode or not (instead of *always* using TEMP mode).

I plan to use the 2p2e4 section for a video, and I'd like to focus on areas of the tool that are less likely to change (or at least are likely to change less).

So let's move the discussion about "export to URL" and TEMP mode to a later part of the document. It's fine if we discuss it later, If a user accidentally ends up in TEMP mode, the tool will warn the user if they try to do edits (at least direct statement edits), and I've documented TEMP mode in the tutorial *and* reference sections.